### PR TITLE
Add buf build step

### DIFF
--- a/.github/workflows/buf-lint.yml
+++ b/.github/workflows/buf-lint.yml
@@ -34,6 +34,8 @@ jobs:
       # Install the `buf` CLI
       - uses: bufbuild/buf-setup-action@v1
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'incompatible protobuf') }}
+      # Ensure the module builds before running breaking or lint.
+      - run: buf build --error-format=github-actions
       # Run breaking change detection against the `main` branch
       - uses: bufbuild/buf-breaking-action@v1
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'incompatible protobuf') }}


### PR DESCRIPTION
This ensures that build errors are caught and reported before breaking and lint run.

Related to https://github.com/bufbuild/buf-lint-action/issues/120 (see that issue for another option)